### PR TITLE
Fix Incorrect Help message of sub_cmd1

### DIFF
--- a/samples/subsys/shell/shell_module/src/test_module.c
+++ b/samples/subsys/shell/shell_module/src/test_module.c
@@ -42,5 +42,5 @@ static int sub_cmd1_handler(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
-SHELL_SUBCMD_COND_ADD(1, (section_cmd, cmd1), sub_cmd1, NULL, "help for cmd2",
+SHELL_SUBCMD_COND_ADD(1, (section_cmd, cmd1), sub_cmd1, NULL, "help for sub_cmd1",
 			sub_cmd1_handler, 1, 0);


### PR DESCRIPTION
Change "help for cmd2" to "help for sub_cmd1".